### PR TITLE
get RRs of Node for migration workflow

### DIFF
--- a/controllers/routereflectorconfig_controller.go
+++ b/controllers/routereflectorconfig_controller.go
@@ -124,11 +124,8 @@ func (r *RouteReflectorConfigReconciler) Reconcile(req ctrl.Request) (ctrl.Resul
 	log.Debugf("Total number of nodes %d", len(nodeList.Items))
 
 	readyNodes, actualRRNumber, nodes := r.collectNodeInfo(nodeList.Items)
-	log.Infof("Nodes are ready %d", readyNodes)
-	log.Infof("Actual number of healthy route reflector nodes are %d", actualRRNumber)
-
 	expectedRRNumber := r.Topology.CalculateExpectedNumber(readyNodes)
-	log.Infof("Expected number of route reflector nodes are %d", expectedRRNumber)
+	log.Infof("Nodes READY=%d, route-reflectors (healthy/expected) = %d/%d", readyNodes, actualRRNumber, expectedRRNumber)
 
 	for n, isReady := range nodes {
 		if status, ok := routeReflectorsUnderOperation[n.GetUID()]; ok {
@@ -200,7 +197,7 @@ func (r *RouteReflectorConfigReconciler) Reconcile(req ctrl.Request) (ctrl.Resul
 	log.Debugf("Current BGPeers are: %v", currentBGPPeers)
 
 	for _, bp := range currentBGPPeers {
-		log.Infof("Saving %s BGPPeer", bp.Name)
+		log.Debugf("Saving %s BGPPeer", bp.Name)
 		if err := r.BGPPeer.SaveBGPPeer(&bp); err != nil {
 			log.Errorf("Unable to save BGPPeer because of %s", err.Error())
 			return bgpPeerError, err

--- a/topologies/multi.go
+++ b/topologies/multi.go
@@ -59,6 +59,12 @@ func (t *MultiTopology) GetNodeLabel(nodeID string) (string, string) {
 	return t.NodeLabelKey, t.getNodeLabel(nodeID)
 }
 
+// GetRRsofNode returns Node object pointers of the RRs of a Node
+// BGPPeers are used to resolve the node<>rr mappings
+func (t *MultiTopology) GetRRsofNode(nodes map[*corev1.Node]bool, existingPeers *calicoApi.BGPPeerList, node *corev1.Node) map[*corev1.Node]bool {
+	return t.single.GetRRsofNode(nodes, existingPeers, node)
+}
+
 func (t *MultiTopology) NewNodeListOptions(nodeLabels map[string]string) client.ListOptions {
 	return client.ListOptions{}
 }

--- a/topologies/single.go
+++ b/topologies/single.go
@@ -18,6 +18,7 @@ package topologies
 import (
 	"fmt"
 	"math"
+	"strings"
 
 	calicoApi "github.com/projectcalico/libcalico-go/lib/apis/v3"
 	corev1 "k8s.io/api/core/v1"
@@ -25,6 +26,8 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/selection"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/prometheus/common/log"
 )
 
 type SingleTopology struct {
@@ -42,6 +45,43 @@ func (t *SingleTopology) GetClusterID(string, int64) string {
 
 func (t *SingleTopology) GetNodeLabel(string) (string, string) {
 	return t.NodeLabelKey, t.NodeLabelValue
+}
+
+// GetRRsofNode returns Node object pointers of the RRs of a Node
+// BGPPeers are used to resolve the node<>rr mappings
+func (t *SingleTopology) GetRRsofNode(nodes map[*corev1.Node]bool, existingPeers *calicoApi.BGPPeerList, node *corev1.Node) map[*corev1.Node]bool {
+	rrIDs := map[string]bool{}
+	rrs := map[*corev1.Node]bool{}
+
+	for _, bp := range existingPeers.Items {
+
+		// Skip rrs-to-rrs which has "has()" NodeSlector
+		if strings.Contains(bp.Name, "rrs-to-rrs") {
+			log.Debugf("Skipping %s", bp.Name)
+			continue
+		}
+
+		// Get rr-id from PeerSelector in BGPeers where the NodeSelector matches the node
+		if t.keyFieldOfSelector(bp.Spec.NodeSelector) == node.Name {
+			peerSelector := t.keyFieldOfSelector(bp.Spec.PeerSelector)
+			log.Debugf("Found rr-id:%s in BGPPeers:%s as existing RR of Node:%s", peerSelector, bp.Name, node.Name)
+			rrIDs[peerSelector] = true
+		}
+	}
+
+	// Find RR Nodes by rr-id in the nodes map
+	for n := range nodes {
+		if _, ok := rrIDs[n.GetLabels()[t.Config.NodeLabelKey]]; ok {
+			log.Debugf("Found %s as existing RR of Node:%s", n.Name, node.Name)
+			rrs[n] = true
+		}
+	}
+
+	return rrs
+}
+
+func (t *SingleTopology) keyFieldOfSelector(s string) (key string) {
+	return strings.ReplaceAll(strings.Split(s, "==")[1], "'", "")
 }
 
 func (t *SingleTopology) NewNodeListOptions(nodeLabels map[string]string) client.ListOptions {

--- a/topologies/topology.go
+++ b/topologies/topology.go
@@ -32,6 +32,7 @@ type Topology interface {
 	IsRouteReflector(string, map[string]string) bool
 	GetClusterID(string, int64) string
 	GetNodeLabel(string) (string, string)
+	GetRRsofNode(map[*corev1.Node]bool, *calicoApi.BGPPeerList, *corev1.Node) map[*corev1.Node]bool
 	NewNodeListOptions(labels map[string]string) client.ListOptions
 	CalculateExpectedNumber(int) int
 	GenerateBGPPeers([]corev1.Node, map[*corev1.Node]bool, *calicoApi.BGPPeerList) []calicoApi.BGPPeer


### PR DESCRIPTION
Based on https://github.com/mhmxs/calico-route-reflector-operator/pull/5:
> This way we always pick the same RRs across reconcile for every Node as long as the list of active RRs and Nodes list doesn't change.