### PR TITLE
wait between BGPPeers refresh and delete

### DIFF
--- a/controllers/routereflectorconfig_controller.go
+++ b/controllers/routereflectorconfig_controller.go
@@ -18,6 +18,7 @@ package controllers
 
 import (
 	"context"
+	"time"
 
 	"github.com/go-logr/logr"
 	"github.com/mhmxs/calico-route-reflector-operator/bgppeer"
@@ -203,6 +204,9 @@ func (r *RouteReflectorConfigReconciler) Reconcile(req ctrl.Request) (ctrl.Resul
 			return bgpPeerError, err
 		}
 	}
+
+	// Wait for new session to Establish
+	time.Sleep(10 * time.Second)
 
 	for _, p := range existingBGPPeers.Items {
 		if !findBGPPeer(currentBGPPeers, p.GetName()) {


### PR DESCRIPTION
The current implementation doesn't provide deterministicity on RR and Node
create/update events as on such events RR and Node lists change enough to
reshuffle all RRs on a larger portion - depending on RR and cluster size - of
the Nodes, leading to a 2s network disruption on them.

To avoid this the operator should wait for the new session to Establish
before tearing down the old ones.

nodes=20 percentageOfNodes=0.024 event=rrdel twosec=0
nodes=20 percentageOfNodes=0.024 event=rrapp twosec=1
nodes=20 percentageOfNodes=0.05 event=rrdel twosec=0
nodes=20 percentageOfNodes=0.05 event=rrapp twosec=1
nodes=100 percentageOfNodes=0.024 event=rrdel twosec=0
nodes=100 percentageOfNodes=0.024 event=rrapp twosec=1
nodes=100 percentageOfNodes=0.05 event=rrdel twosec=0
nodes=100 percentageOfNodes=0.05 event=rrapp twosec=11
nodes=200 percentageOfNodes=0.024 event=rrdel twosec=0
nodes=200 percentageOfNodes=0.024 event=rrapp twosec=1
nodes=200 percentageOfNodes=0.05 event=rrdel twosec=100
nodes=200 percentageOfNodes=0.05 event=rrapp twosec=104
nodes=300 percentageOfNodes=0.024 event=rrdel twosec=84
nodes=300 percentageOfNodes=0.024 event=rrapp twosec=103
nodes=300 percentageOfNodes=0.05 event=rrdel twosec=189
nodes=300 percentageOfNodes=0.05 event=rrapp twosec=211
nodes=400 percentageOfNodes=0.024 event=rrdel twosec=167
nodes=400 percentageOfNodes=0.024 event=rrapp twosec=197
nodes=400 percentageOfNodes=0.05 event=rrdel twosec=283
nodes=400 percentageOfNodes=0.05 event=rrapp twosec=313
nodes=500 percentageOfNodes=0.024 event=rrdel twosec=279
nodes=500 percentageOfNodes=0.024 event=rrapp twosec=309
nodes=500 percentageOfNodes=0.05 event=rrdel twosec=395
nodes=500 percentageOfNodes=0.05 event=rrapp twosec=391